### PR TITLE
Read BROKER_TIMEOUT from env or localStorage to override the message …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerodensity/realityhub-api",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "RealityHub API Javascript Implementation",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
…timeout in milliseconds

Signed-off-by: Bülent Vural <bulent.vural@zerodensity.tv>